### PR TITLE
Replace write queue/thread with a lock

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -9,6 +9,7 @@ import nox
 MODULE_NAME = "objeggtives"
 TESTS_PATH = "tests"
 COVERAGE_FAIL_UNDER = 0
+DEFAULT_PYTHON = "3.11"
 REQUIREMENT_IN_FILES = [
     pathlib.Path("requirements/requirements.in"),
     pathlib.Path("requirements/requirements-dev.in"),
@@ -50,7 +51,7 @@ def tests_with_coverage(session: nox.Session) -> None:
     session.run("coverage", "run", "-p", "-m", "pytest", TESTS_PATH)
 
 
-@nox.session()
+@nox.session(python=DEFAULT_PYTHON)
 def coverage_combine_and_report(session: nox.Session) -> None:
     """Combine all coverage partial files and generate JSON report."""
     print_standard_logs(session)
@@ -63,7 +64,7 @@ def coverage_combine_and_report(session: nox.Session) -> None:
     session.run("python", "-m", "coverage", "json")
 
 
-@nox.session()
+@nox.session(python=DEFAULT_PYTHON)
 def mypy_check(session: nox.Session) -> None:
     """Run mypy against package and all required dependencies."""
     print_standard_logs(session)
@@ -88,7 +89,7 @@ def docker(session: nox.Session) -> None:
     session.run("docker", "run", "-it", "--rm", "pydocker-test")
 
 
-@nox.session()
+@nox.session(python=DEFAULT_PYTHON)
 def build(session: nox.Session) -> None:
     """Build distrobution files."""
     print_standard_logs(session)
@@ -97,7 +98,7 @@ def build(session: nox.Session) -> None:
     session.run("python", "-m", "build")
 
 
-@nox.session()
+@nox.session(python=DEFAULT_PYTHON)
 def update(session: nox.Session) -> None:
     """Process requirement*.in files, updating only additions/removals."""
     print_standard_logs(session)
@@ -107,7 +108,7 @@ def update(session: nox.Session) -> None:
         session.run("pip-compile", "--no-emit-index-url", str(filename))
 
 
-@nox.session()
+@nox.session(python=DEFAULT_PYTHON)
 def upgrade(session: nox.Session) -> None:
     """Process requirement*.in files and upgrade all libraries as possible."""
     print_standard_logs(session)

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -4,29 +4,29 @@
 #
 #    pip-compile --no-emit-index-url requirements/requirements-dev.in
 #
-black==23.10.1
+black==24.2.0
     # via -r requirements/requirements-dev.in
 cfgv==3.4.0
     # via pre-commit
 click==8.1.7
     # via black
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
-filelock==3.13.0
+filelock==3.13.1
     # via virtualenv
-flake8==6.1.0
+flake8==7.0.0
     # via
     #   -r requirements/requirements-dev.in
     #   flake8-builtins
-flake8-builtins==2.1.0
+flake8-builtins==2.2.0
     # via -r requirements/requirements-dev.in
 flake8-pep585==0.1.7
     # via -r requirements/requirements-dev.in
-identify==2.5.31
+identify==2.5.35
     # via pre-commit
 mccabe==0.7.0
     # via flake8
-mypy==1.6.1
+mypy==1.9.0
     # via -r requirements/requirements-dev.in
 mypy-extensions==1.0.0
     # via
@@ -34,25 +34,25 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.2
+packaging==24.0
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.11.0
+platformdirs==4.2.0
     # via
     #   black
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.2
     # via -r requirements/requirements-dev.in
 pycodestyle==2.11.1
     # via flake8
-pyflakes==3.1.0
+pyflakes==3.2.0
     # via flake8
 pyyaml==6.0.1
     # via pre-commit
-typing-extensions==4.8.0
+typing-extensions==4.10.0
     # via mypy
-virtualenv==20.24.6
+virtualenv==20.25.1
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -4,33 +4,33 @@
 #
 #    pip-compile --no-emit-index-url requirements/requirements-test.in
 #
-argcomplete==3.1.2
+argcomplete==3.2.3
     # via nox
-colorlog==6.7.0
+colorlog==6.8.2
     # via nox
-coverage==7.3.2
+coverage==7.4.3
     # via -r requirements/requirements-test.in
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
-filelock==3.13.0
+filelock==3.13.1
     # via virtualenv
 iniconfig==2.0.0
     # via pytest
-nox==2023.4.22
+nox==2024.3.2
     # via -r requirements/requirements-test.in
-packaging==23.2
+packaging==24.0
     # via
     #   nox
     #   pytest
-platformdirs==3.11.0
+platformdirs==4.2.0
     # via virtualenv
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
-pytest==7.4.3
+pytest==8.1.1
     # via
     #   -r requirements/requirements-test.in
     #   pytest-randomly
 pytest-randomly==3.15.0
     # via -r requirements/requirements-test.in
-virtualenv==20.24.6
+virtualenv==20.25.1
     # via nox

--- a/src/objeggtives/liststore.py
+++ b/src/objeggtives/liststore.py
@@ -7,8 +7,6 @@ import enum
 import os
 import sqlite3
 import threading
-from queue import Empty
-from queue import Queue
 
 from .struclogger import get_logger
 
@@ -44,9 +42,6 @@ class ListItem:
 class ListStore:
     """Handle the database connection and operations within a context manager."""
 
-    # Keep the queue timeout low to allow for quick shutdown but not too low to cause
-    # excessive CPU usage in the writer thread.
-    QUEUE_TIMEOUT = 0.5
     _logger = get_logger(__name__)
 
     def __init__(self, database: str) -> None:
@@ -65,15 +60,13 @@ class ListStore:
             raise FileNotFoundError(f"Database file {database} does not exist.")
 
         self.database = database
-        self._connected = False
-        self._reader: sqlite3.Connection | None = None
-        self._writer = threading.Thread()
-        self._writer_queue: Queue[ListItem] = Queue()
+        self._connection: sqlite3.Connection | None = None
+        self._writer_lock: threading.Lock = threading.Lock()
 
     @property
     def connected(self) -> bool:
         """Return the connection status of the database."""
-        return self._connected
+        return bool(self._connection)
 
     @classmethod
     def initialize(cls, database: str) -> ListStore:
@@ -89,36 +82,42 @@ class ListStore:
         if database != ":memory:" and os.path.exists(database):
             raise FileExistsError(f"Database file {database} already exists.")
 
-        with sqlite3.connect(database) as conn:
-            ListStore._logger.debug("Creating tables in database %s", database)
-            ListStore._create_tables(conn)
+        sqlite3.connect(database).close()
+        liststore = cls(database)
 
-        return cls(database)
+        with liststore as store:
+            store._logger.debug("Creating tables in database %s", database)
+            store._create_tables()
 
-    @staticmethod
-    def _create_tables(conn: sqlite3.Connection) -> None:
+        return liststore
+
+    def _create_tables(self) -> None:
         """Create the table if it does not exist."""
-        conn.execute(
-            """\
-            CREATE TABLE IF NOT EXISTS liststore (
-                row_id INTEGER PRIMARY KEY,
-                author INTEGER NOT NULL,
-                created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL,
-                closed_at INTEGER,
-                message_reference INTEGER,
-                message TEXT NOT NULL,
-                priority INTEGER NOT NULL DEFAULT 1
-            );"""
-        )
-        conn.execute(
-            """\
-            CREATE UNIQUE INDEX IF NOT EXISTS
-                idx_row
-            ON
-                liststore (author, message_reference);
-            """
-        )
+        if not self._connection:
+            raise sqlite3.Error("Database connection is closed.")
+
+        with self._writer_lock:
+            self._connection.execute(
+                """\
+                CREATE TABLE IF NOT EXISTS liststore (
+                    row_id INTEGER PRIMARY KEY,
+                    author INTEGER NOT NULL,
+                    created_at INTEGER NOT NULL,
+                    updated_at INTEGER NOT NULL,
+                    closed_at INTEGER,
+                    message_reference INTEGER,
+                    message TEXT NOT NULL,
+                    priority INTEGER NOT NULL DEFAULT 1
+                );"""
+            )
+            self._connection.execute(
+                """\
+                CREATE UNIQUE INDEX IF NOT EXISTS
+                    idx_row
+                ON
+                    liststore (author, message_reference);
+                """
+            )
 
     def open(self) -> None:  # noqa: A003 # Allow shadowing of built-in 'open'
         """
@@ -130,23 +129,16 @@ class ListStore:
         Raises:
             sqlite3.Error: If the database connection cannot be established.
         """
-        if self._reader is not None:
+        if self._connection is not None:
             raise sqlite3.Error("Database connection already open.")
 
-        self._reader = sqlite3.connect(self.database)
-        self._connected = True
+        self._connection = sqlite3.connect(self.database, check_same_thread=False)
         self._logger.debug("Opened database connection to %s", self.database)
 
         # If we are a memory database the tables need to be created for this connection.
         if self.database == ":memory:":
             self._logger.debug("Creating tables in memory database")
-            self._create_tables(self._reader)
-
-        # Create a writer thread to handle asynchronous processes wanting to write to the database.
-        self._logger.debug("Starting writer thread")
-        self._writer = threading.Thread(target=self._writer_thread)
-        self._writer.start()
-        self._logger.debug("Started writer thread")
+            self._create_tables()
 
     def close(self) -> None:
         """
@@ -155,24 +147,19 @@ class ListStore:
         Raises:
             sqlite3.Error: If the database connection is already closed.
         """
-        if self._reader is None:
+        if self._connection is None:
             raise sqlite3.Error("Database connection already closed.")
 
-        self._reader.close()
-        self._reader = None
-        self._connected = False
+        self._connection.close()
+        self._connection = None
         self._logger.debug("Closed database connection to %s", self.database)
-        self._logger.debug("Waiting for writer thread to finish...")
-        self._writer.join()
-        self._logger.debug("Writer thread finished and closed.")
 
     def write(self, item: ListItem) -> None:
         """
         Write an item to the database.
 
-        This operates as a non-blocking operation and will queue the item for
-        writing. The item will be created or updated in the database based on
-        the message_reference and author.
+        This operation is a thread-safe write to the sqlite3 database. The
+        operation is blocking until the item is written to the database.
 
         Args:
             item: The item to write to the database.
@@ -180,15 +167,38 @@ class ListStore:
         Raises:
             sqlite3.Error: If the database connection is closed.
         """
-        if not self.connected:
+        if not self._connection:
             raise sqlite3.Error("Database connection is closed.")
-        self._writer_queue.put(item)
-        self._logger.debug(
-            "Queued item for writing. %s, %s, %s",
-            item.author,
-            item.message_reference,
-            item.message,
-        )
+
+        with self._writer_lock:
+            self._connection.execute(
+                """\
+                INSERT INTO liststore (
+                    author,
+                    created_at,
+                    updated_at,
+                    closed_at,
+                    message_reference,
+                    message,
+                    priority
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(author, message_reference) DO UPDATE SET
+                    updated_at = excluded.updated_at,
+                    closed_at = excluded.closed_at,
+                    message = excluded.message,
+                    priority = excluded.priority;
+                """,
+                (
+                    item.author,
+                    item.created_at,
+                    item.updated_at,
+                    item.closed_at,
+                    item.message_reference,
+                    item.message,
+                    item.priority.value,
+                ),
+            )
+            self._connection.commit()
 
     def __enter__(self) -> ListStore:
         """Context manager entry point."""
@@ -198,56 +208,3 @@ class ListStore:
     def __exit__(self, exc_type, exc_value, traceback) -> None:  # type: ignore
         """Context manager exit point."""
         self.close()
-
-    def _writer_thread(self) -> None:
-        """Thread target for writing to the database."""
-        try:
-            connection = sqlite3.connect(self.database)
-
-            while "On a dark desert highway, cool wind in my hair":
-                try:
-                    item = self._writer_queue.get(timeout=self.QUEUE_TIMEOUT)
-                    self._logger.debug(
-                        "Writing to database. %s, %s",
-                        item.author,
-                        item.message_reference,
-                    )
-                    self._write_row(item, connection)
-
-                except Empty:
-                    if not self.connected:
-                        break
-
-        finally:
-            connection.close()
-
-    def _write_row(self, item: ListItem, connection: sqlite3.Connection) -> None:
-        """Write a row to the database."""
-        connection.execute(
-            """\
-            INSERT INTO liststore (
-                author,
-                created_at,
-                updated_at,
-                closed_at,
-                message_reference,
-                message,
-                priority
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(author, message_reference) DO UPDATE SET
-                updated_at = excluded.updated_at,
-                closed_at = excluded.closed_at,
-                message = excluded.message,
-                priority = excluded.priority;
-            """,
-            (
-                item.author,
-                item.created_at,
-                item.updated_at,
-                item.closed_at,
-                item.message_reference,
-                item.message,
-                item.priority.value,
-            ),
-        )
-        connection.commit()


### PR DESCRIPTION
This replaces the writer thread and queue system with a much simpler
lock. When any thread writes to the database the action will be blocked
until completed. Only one thread will be allowed to write at a given
time.